### PR TITLE
Add reverse-proxy-auth-plugin

### DIFF
--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -34,3 +34,4 @@ parameterized-trigger:latest
 build-pipeline-plugin:latest
 delivery-pipeline-plugin:latest
 promoted-builds:latest
+reverse-proxy-auth-plugin:latest


### PR DESCRIPTION
I did some testing and there seem to be some issues with the reverse proxy as it is setup currently.

It seems to me this will be the easiest way to get auth up and running properly. We'll also have to pair on the revproxies config as it stands now.

I tried to fix it but kept running into reverse proxy errors on the management page. It seems like I'm getting conflicting auth requests from the proxy and from jenkins and this seems to fix it.

More info on the plugin is [here](https://wiki.jenkins-ci.org/display/JENKINS/Reverse+Proxy+Auth+Plugin).

@dukje merge this at your leisure and I'll install it when the hub build is through.
