### PR TITLE
Switch to role-strategy from matrix-auth

### DIFF
--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -24,7 +24,7 @@ log-command:latest
 mailer:latest
 jabber:latest
 cloudbees-folder:latest
-matrix-auth:latest
+role-strategy:latest
 gravatar:latest
 console-column-plugin:latest
 ruby:latest


### PR DESCRIPTION
We'll have to deploy this change in a controlled manner. Maybe take jenkins offline at the revproxy during the update or something. On the configuration level there is no automated migration path, we just configure [role-strategy](https://wiki.jenkins-ci.org/display/JENKINS/Role+Strategy+Plugin) in a fitting manner after the deploy.

The legacy configuration from matrix-auth (somewhere in `/var/lib/jenkins`) can be deleted after we confirm that we won't be rolling this change back.

Merge this when you're ready to wait on dockerhub ;)
