### PR TITLE
Update to java7 for jenkins

### DIFF
--- a/ruby-1.9.3-jenkins-slave/Dockerfile
+++ b/ruby-1.9.3-jenkins-slave/Dockerfile
@@ -1,7 +1,7 @@
 FROM pfadipatria/ruby-1.9.3
 
 RUN apt-get update && \
- apt-get install openssh-server default-jre -y && \
+ apt-get install openssh-server java7-runtime -y && \
  mkdir /var/run/sshd && \
  adduser jenkins && \
  echo "jenkins:jenkins" | chpasswd


### PR DESCRIPTION
This is needed by the ssh-slave-plugin as per https://issues.jenkins-ci.org/browse/JENKINS-30561
