### PR TITLE
Feature/mediawiki image

### DIFF
--- a/mediawiki-base/Dockerfile
+++ b/mediawiki-base/Dockerfile
@@ -1,0 +1,49 @@
+FROM php:5.6-apache
+MAINTAINER Karbon <karbon@pfadipatria.com>
+
+ENV MEDIAWIKI_VERSION 1.26
+ENV MEDIAWIKI_FULL_VERSION 1.26.2
+
+RUN set -x; \
+    apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libicu52 \
+        libicu-dev \
+    && pecl install intl \
+    && echo extension=intl.so >> /usr/local/etc/php/conf.d/ext-intl.ini \
+    && apt-get purge -y --auto-remove libicu-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-install mysqli opcache
+
+RUN set -x; \
+    apt-get update \
+    && apt-get install -y --no-install-recommends imagemagick \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN a2enmod rewrite
+
+# https://www.mediawiki.org/keys/keys.txt
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
+    441276E9CCD15F44F6D97D18C119E1A64D70938E \
+    41B2ABE817ADD3E52BDA946F72BC1C5D23107F8A \
+    162432D9E81C1C618B301EECEE1F663462D84F01 \
+    1D98867E82982C8FE0ABC25F9B69B3109D3BB7B0 \
+    3CEF8262806D3F0B6BA1DBDD7956EE477F901A30 \
+    280DB7845A1DCAC92BB5A00A946B02565DC00AA7
+
+RUN MEDIAWIKI_DOWNLOAD_URL="https://releases.wikimedia.org/mediawiki/$MEDIAWIKI_VERSION/mediawiki-$MEDIAWIKI_FULL_VERSION.tar.gz"; \
+    set -x; \
+    mkdir -p /usr/src/mediawiki \
+    && curl -fSL "$MEDIAWIKI_DOWNLOAD_URL" -o mediawiki.tar.gz \
+    && curl -fSL "${MEDIAWIKI_DOWNLOAD_URL}.sig" -o mediawiki.tar.gz.sig \
+    && gpg --verify mediawiki.tar.gz.sig \
+    && tar -xf mediawiki.tar.gz -C /usr/src/mediawiki --strip-components=1
+
+
+COPY apache/mediawiki.conf /etc/apache2/
+RUN echo Include /etc/apache2/mediawiki.conf >> /etc/apache2/apache2.conf
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/mediawiki-base/README.md
+++ b/mediawiki-base/README.md
@@ -1,0 +1,39 @@
+# What is MediaWiki?
+
+MediaWiki is a free and open-source wiki app, used to power wiki websites such
+as Wikipedia, Wiktionary and Commons, developed by the Wikimedia Foundation and
+others.
+
+> [wikipedia.org/wiki/MediaWiki](https://en.wikipedia.org/wiki/MediaWiki)
+
+# How to use this image
+
+    docker run --name some-mediawiki --link some-mysql:mysql -d pfadipatria/mediawiki-base
+
+The following environment variables are also honored for configuring your
+MediaWiki instance:
+
+ - `-e MEDIAWIKI_DB_HOST=ADDR:PORT` (defaults to the address and port of the
+   linked mysql container)
+ - `-e MEDIAWIKI_DB_USER=...` (defaults to "root")
+ - `-e MEDIAWIKI_DB_PASSWORD=...` (defaults to the value of the
+   `MYSQL_ROOT_PASSWORD` environment variable from the linked mysql container)
+ - `-e MEDIAWIKI_DB_NAME=...` (defaults to "mediawiki")
+
+If the `MEDIAWIKI_DB_NAME` specified does not already exist in the given MySQL
+container,  it will be created automatically upon container startup, provided
+that the `MEDIAWIKI_DB_USER` specified has the necessary permissions to create
+it.
+
+To use with an external database server, use `MEDIAWIKI_DB_HOST` (along with
+`MEDIAWIKI_DB_USER` and `MEDIAWIKI_DB_PASSWORD` if necessary):
+
+    docker run --name some-mediawiki -e MEDIAWIKI_DB_HOST=10.0.0.1:3306 \
+        -e MEDIAWIKI_DB_USER=app -e MEDIAWIKI_DB_PASSWORD=secure pfadipatria/mediawiki-base
+
+If you'd like to be able to access the instance from the host without the
+container's IP, standard port mappings can be used:
+
+    docker run --name some-mediawiki --link some-mysql:mysql -p 8080:80 -d pfadipatria/mediawiki-base
+
+Then, access it via `http://localhost:8080` or `http://host-ip:8080` in a browser.

--- a/mediawiki-base/apache/mediawiki.conf
+++ b/mediawiki-base/apache/mediawiki.conf
@@ -1,0 +1,19 @@
+<Directory /var/www/html>
+  RewriteEngine On
+  RewriteBase /
+  RewriteRule ^index\.php$ - [L]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule . /index.php [L]
+</Directory>
+
+<Directory /var/www/html/images>
+  # Ignore .htaccess files
+  AllowOverride None
+
+  # Serve HTML as plaintext, don't execute SHTML
+  AddType text/plain .html .htm .shtml .php
+
+  # Don't run arbitrary PHP code.
+  php_admin_flag engine off
+</Directory>

--- a/mediawiki-base/docker-entrypoint.sh
+++ b/mediawiki-base/docker-entrypoint.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -e
+
+: ${MEDIAWIKI_SITE_NAME:=MediaWiki}
+
+if [ -z "$MEDIAWIKI_DB_HOST" -a -z "$MYSQL_PORT_3306_TCP" ]; then
+	echo >&2 'error: missing MYSQL_PORT_3306_TCP environment variable'
+	echo >&2 '  Did you forget to --link some_mysql_container:mysql ?'
+	exit 1
+fi
+
+# if we're linked to MySQL, and we're using the root user, and our linked
+# container has a default "root" password set up and passed through... :)
+: ${MEDIAWIKI_DB_USER:=root}
+if [ "$MEDIAWIKI_DB_USER" = 'root' ]; then
+	: ${MEDIAWIKI_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
+fi
+: ${MEDIAWIKI_DB_NAME:=mediawiki}
+
+if [ -z "$MEDIAWIKI_DB_PASSWORD" ]; then
+	echo >&2 'error: missing required MEDIAWIKI_DB_PASSWORD environment variable'
+	echo >&2 '  Did you forget to -e MEDIAWIKI_DB_PASSWORD=... ?'
+	echo >&2
+	echo >&2 '  (Also of interest might be MEDIAWIKI_DB_USER and MEDIAWIKI_DB_NAME.)'
+	exit 1
+fi
+
+if ! [ -e index.php -a -e includes/DefaultSettings.php ]; then
+	echo >&2 "MediaWiki not found in $(pwd) - copying now..."
+
+	if [ "$(ls -A)" ]; then
+		echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
+		( set -x; ls -A; sleep 10 )
+	fi
+	tar cf - --one-file-system -C /usr/src/mediawiki . | tar xf -
+	echo >&2 "Complete! MediaWiki has been successfully copied to $(pwd)"
+fi
+
+: ${MEDIAWIKI_SHARED:=/var/www-shared/html}
+if [ -d "$MEDIAWIKI_SHARED" ]; then
+	# If there is no LocalSettings.php but we have one under the shared
+	# directory, symlink it
+	if [ -e "$MEDIAWIKI_SHARED/LocalSettings.php" -a ! -e LocalSettings.php ]; then
+		ln -s "$MEDIAWIKI_SHARED/LocalSettings.php" LocalSettings.php
+	fi
+
+	# If the images directory only contains a README, then link it to
+	# $MEDIAWIKI_SHARED/images, creating the shared directory if necessary
+	if [ "$(ls images)" = "README" -a ! -L images ]; then
+		rm -fr images
+		mkdir -p "$MEDIAWIKI_SHARED/images"
+		ln -s "$MEDIAWIKI_SHARED/images" images
+	fi
+fi
+
+: ${MEDIAWIKI_DB_HOST:=${MYSQL_PORT_3306_TCP#tcp://}}
+
+TERM=dumb php -- "$MEDIAWIKI_DB_HOST" "$MEDIAWIKI_DB_USER" "$MEDIAWIKI_DB_PASSWORD" "$MEDIAWIKI_DB_NAME" <<'EOPHP'
+<?php
+// database might not exist, so let's try creating it (just to be safe)
+
+list($host, $port) = explode(':', $argv[1], 2);
+$mysql = new mysqli($host, $argv[2], $argv[3], '', (int)$port);
+
+if ($mysql->connect_error) {
+	file_put_contents('php://stderr', 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
+	exit(1);
+}
+
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($argv[4]) . '`')) {
+	file_put_contents('php://stderr', 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
+	$mysql->close();
+	exit(1);
+}
+
+$mysql->close();
+EOPHP
+
+chown -R www-data: .
+
+export MEDIAWIKI_SITE_NAME MEDIAWIKI_DB_HOST MEDIAWIKI_DB_USER MEDIAWIKI_DB_PASSWORD MEDIAWIKI_DB_NAME
+
+exec "$@"

--- a/mediawiki-extended/Dockerfile
+++ b/mediawiki-extended/Dockerfile
@@ -1,0 +1,54 @@
+FROM pfadipatria/mediawiki-base
+
+ENV MEDIAWIKI_EXT_BRANCH REL1_26
+
+RUN set -x; \
+    apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && apt-get install -y --no-install-recommends zlib1g-dev \
+    && docker-php-ext-install zip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-install mbstring
+
+RUN curl -sS https://getcomposer.org/installer | php \
+    && mv composer.phar /usr/local/bin/composer
+
+# Install composer based extensions
+RUN cd /usr/src/mediawiki/ \
+    && composer require mediawiki/semantic-media-wiki "~2.3" --update-no-dev
+
+RUN cd /usr/src/mediawiki/ \
+    && composer require mediawiki/semantic-result-formats "~2.3" --update-no-dev
+
+# Install extensions with a git based install
+RUN set -x; \
+    git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/VisualEditor.git /usr/src/mediawiki/extensions/VisualEditor \
+    && cd /usr/src/mediawiki/extensions/VisualEditor \
+    && git submodule update --init 
+
+RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/CategoryTree.git /usr/src/mediawiki/extensions/CategoryTree
+
+RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/ExternalData.git /usr/src/mediawiki/extensions/ExternalData
+
+RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/SemanticInternalObjects.git /usr/src/mediawiki/extensions/SemanticInternalObjects
+
+RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/SemanticCompoundQueries.git /usr/src/mediawiki/extensions/SemanticCompoundQueries
+
+RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/SemanticDrilldown.git /usr/src/mediawiki/extensions/SemanticDrilldown
+
+RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/SemanticForms.git /usr/src/mediawiki/extensions/SemanticForms
+
+RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/SemanticFormsInputs.git /usr/src/mediawiki/extensions/SemanticFormsInputs
+
+RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/SemanticImageInput.git /usr/src/mediawiki/extensions/SemanticImageInput
+
+RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/Arrays.git /usr/src/mediawiki/extensions/Arrays
+
+RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/HeaderTabs.git /usr/src/mediawiki/extensions/HeaderTabs
+
+RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/ApprovedRevs.git /usr/src/mediawiki/extensions/ApprovedRevs
+
+RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/Interwiki.git /usr/src/mediawiki/extension/Interwiki
+
+COPY LocalSettings.php /var/www/html/LocalSettings.php 

--- a/mediawiki-extended/LocalSettings.php
+++ b/mediawiki-extended/LocalSettings.php
@@ -1,0 +1,185 @@
+<?php
+# See includes/DefaultSettings.php for all configurable settings
+# and their default values, but don't forget to make changes in _this_
+# file, not there.
+#
+# Further documentation for configuration settings may be found at:
+# https://www.mediawiki.org/wiki/Manual:Configuration_settings
+
+# Protect against web entry
+if ( !defined( 'MEDIAWIKI' ) ) {
+	exit;
+}
+
+ini_set('display_errors', false);
+
+## Uncomment this to disable output compression
+# $wgDisableOutputCompression = true;
+
+$wgSitename = getenv('MW_WG_SITENAME');
+$wgMetaNamespace = getenv('MW_WG_METANAMESPACE');
+
+## The URL base path to the directory containing the wiki;
+## defaults for all runtime URL paths are based off of this.
+## For more information on customizing the URLs
+## (like /w/index.php/Page_title to /wiki/Page_title) please see:
+## https://www.mediawiki.org/wiki/Manual:Short_URL
+$wgScriptPath = "";
+$wgScriptExtension = ".php";
+
+## Path to articles is set up so that pages are reachable on /Page_Name
+$wgArticlePath = "/$1";
+
+## The protocol and server name to use in fully-qualified URLs
+$wgServer = getenv('MW_WG_SERVER');
+
+## The relative URL path to the skins directory
+$wgStylePath = "$wgScriptPath/skins";
+
+## The relative URL path to the logo.  Make sure you change this from the default,
+## or else you'll overwrite your logo when you upgrade!
+$wgLogo = "$wgScriptPath/resources/assets/wiki.png";
+
+## UPO means: this is also a user preference option
+
+$wgEnableEmail = true;
+$wgEnableUserEmail = true; # UPO
+
+$wgEmergencyContact = "apache@localhost";
+$wgPasswordSender = "apache@localhost";
+
+$wgEnotifUserTalk = false; # UPO
+$wgEnotifWatchlist = false; # UPO
+$wgEmailAuthentication = true;
+
+## Database settings
+$wgDBtype = "mysql";
+$wgDBserver = "mysql";
+$wgDBname = "mediawiki";
+$wgDBuser = getenv('MW_WG_DBUSER');
+$wgDBpassword = getenv('MW_WG_DBPASS');
+
+# MySQL specific settings
+$wgDBprefix = "";
+
+# MySQL table options to use during installation or update
+$wgDBTableOptions = "ENGINE=InnoDB, DEFAULT CHARSET=utf8";
+
+# Experimental charset support for MySQL 5.0.
+$wgDBmysql5 = true;
+
+## Shared memory settings
+$wgMainCacheType = CACHE_NONE;
+$wgMemCachedServers = array();
+
+## To enable image uploads, make sure the 'images' directory
+## is writable, then set this to true:
+$wgEnableUploads = false;
+$wgUseImageMagick = true;
+$wgImageMagickConvertCommand = "/usr/bin/convert";
+
+# InstantCommons allows wiki to use images from http://commons.wikimedia.org
+$wgUseInstantCommons = false;
+
+## If you use ImageMagick (or any other shell command) on a
+## Linux server, this will need to be set to the name of an
+## available UTF-8 locale
+$wgShellLocale = "C.UTF-8";
+
+## If you want to use image uploads under safe mode,
+## create the directories images/archive, images/thumb and
+## images/temp, and make them all writable. Then uncomment
+## this, if it's not already uncommented:
+#$wgHashedUploadDirectory = false;
+
+## Set $wgCacheDirectory to a writable directory on the web server
+## to make your wiki go slightly faster. The directory should not
+## be publically accessible from the web.
+#$wgCacheDirectory = "$IP/cache";
+
+# Site language code, should be one of the list in ./languages/Names.php
+$wgLanguageCode = getenv("MW_WG_LANGUAGECODE");
+
+$wgSecretKey = "1a0e46df5a9081c7c790dbf60588eea56c87c9634e155572cc2da879147539a3";
+
+# Site upgrade key. Must be set to a string (default provided) to turn on the
+# web installer while LocalSettings.php is in place
+$wgUpgradeKey = "b31022590a7b3b8f";
+
+## For attaching licensing metadata to pages, and displaying an
+## appropriate copyright notice / icon. GNU Free Documentation
+## License and Creative Commons licenses are supported so far.
+$wgRightsPage = ""; # Set to the title of a wiki page that describes your license/copyright
+$wgRightsUrl = "";
+$wgRightsText = "";
+$wgRightsIcon = "";
+
+# Path to the GNU diff3 utility. Used for conflict resolution.
+$wgDiff3 = "/usr/bin/diff3";
+
+## Default skin: you can change the default skin. Use the internal symbolic
+## names, ie 'vector', 'monobook':
+$wgDefaultSkin = "vector";
+
+# Enabled skins.
+# The following skins were automatically enabled:
+require_once "$IP/skins/CologneBlue/CologneBlue.php";
+require_once "$IP/skins/Modern/Modern.php";
+require_once "$IP/skins/MonoBook/MonoBook.php";
+require_once "$IP/skins/Vector/Vector.php";
+
+
+# Enabled Extensions. Most extensions are enabled by including the base extension file here
+# but check specific extension documentation for more details
+# The following extensions were automatically enabled:
+require_once "$IP/extensions/Cite/Cite.php";
+require_once "$IP/extensions/Interwiki/Interwiki.php";
+require_once "$IP/extensions/Renameuser/Renameuser.php";
+require_once "$IP/extensions/SpamBlacklist/SpamBlacklist.php";
+require_once "$IP/extensions/SyntaxHighlight_GeSHi/SyntaxHighlight_GeSHi.php";
+require_once "$IP/extensions/ParserFunctions/ParserFunctions.php";
+
+# VisualEditor Extension
+require_once "$IP/extensions/VisualEditor/VisualEditor.php";
+
+# Enable by default for everybody
+$wgDefaultUserOptions['visualeditor-enable'] = 1;
+
+# Don't allow users to disable it
+# $wgHiddenPrefs[] = 'visualeditor-enable';
+
+# OPTIONAL: Enable VisualEditor's experimental code features
+# #$wgDefaultUserOptions['visualeditor-enable-experimental'] = 1;
+
+$wgVirtualRestConfig['modules']['parsoid'] = array(
+  // URL to the Parsoid instance
+  'url' => 'http://parsoid:8000',
+  'domain' => 'localhost',
+  'prefix' => 'localhost',
+);
+
+# CategoryTree Extension
+require_once "$IP/extensions/CategoryTree/CategoryTree.php";
+$wgUseAjax = true;
+
+# ExternalData
+require_once "$IP/extensions/ExternalData/ExternalData.php";
+
+# Semantic Stuff
+require_once "$IP/extensions/SemanticMediaWiki/SemanticMediaWiki.php";
+require_once "$IP/extensions/SemanticInternalObjects/SemanticInternalObjects.php";
+require_once "$IP/extensions/SemanticInternalObjects/SemanticInternalObjects.php";
+require_once "$IP/extensions/SemanticCompoundQueries/SemanticCompoundQueries.php";
+require_once "$IP/extensions/SemanticDrilldown/SemanticDrilldown.php";
+require_once "$IP/extensions/SemanticForms/SemanticForms.php";
+require_once "$IP/extensions/SemanticFormsInputs/SemanticFormsInputs.php";
+require_once "$IP/extensions/SemanticImageInput/SemanticImageInput.php";
+
+# more exts
+require_once "$IP/extensions/Arrays/Arrays.php";
+require_once "$IP/extensions/HeaderTabs/HeaderTabs.php";
+require_once "$IP/extensions/ApprovedRevs/ApprovedRevs.php";
+
+if (getenv('MV_WG_RAWHTML') === 'true') {
+    $wgRawHtml = true;
+}


### PR DESCRIPTION
Based on https://github.com/appropriate/docker-mediawiki version 1.25 and bumped to 1.26.

This needs to get merged so I can configure it on dockerhub. I'll add patria specific in an imaged derived from this to keep this somewhat reusable.

The extension selection is very much opinionated and it's pretty much ready for use with a docker-compose file I'll push later.

Before everything works I still got some auth stuff to sort out, I'm testing an auth strategy that can be done at the proxy layer and we'll need to integrate that with ldap/pam after I get around to testing/pushing it.
